### PR TITLE
fix pip install bug

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/Sanster/lama-cleaner",
-    packages=setuptools.find_packages("./"),
+    packages=setuptools.find_packages("."),
     package_data={"lama_cleaner": web_files},
     install_requires=load_requirements(),
     python_requires=">=3.7",


### PR DESCRIPTION
Collecting git+https://github.com/yizhangliu/lama-cleaner.git@main
  Cloning https://github.com/yizhangliu/lama-cleaner.git (to revision main) to c:\users\user\appdata\local\temp\pip-req-build-bl4ilqog
  Running command git clone --filter=blob:none --quiet https://github.com/yizhangliu/lama-cleaner.git 'C:\Users\user\AppData\Local\Temp\pip-req-build-bl4ilqog'
  Resolved https://github.com/yizhangliu/lama-cleaner.git to commit 658ee0d4257499528d8781440787ca0596794eaf
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error

  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [10 lines of output]
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "C:\Users\user\AppData\Local\Temp\pip-req-build-bl4ilqog\setup.py", line 31, in <module>
          packages=setuptools.find_packages("./"),
        File "C:\Users\user\anaconda3\envs\gsa\lib\site-packages\setuptools\__init__.py", line 65, in find
          convert_path(where),
        File "C:\Users\user\anaconda3\envs\gsa\lib\site-packages\setuptools\_distutils\util.py", line 182, in convert_path
          raise ValueError("path '%s' cannot end with '/'" % pathname)
      ValueError: path './' cannot end with '/'
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.